### PR TITLE
add an option to filter

### DIFF
--- a/mautic/api.py
+++ b/mautic/api.py
@@ -118,6 +118,7 @@ class API(object):
     def get_list(
         self,
         search='',
+        where={},
         start=0,
         limit=0,
         order_by='',
@@ -139,10 +140,14 @@ class API(object):
         """
 
         parameters = {}
-        args = ['search', 'start', 'limit', 'minimal']
+        args = ['search', 'start', 'limit', 'minimal', 'where']
         for arg in args:
             if arg in locals() and locals()[arg]:
-                parameters[arg] = locals()[arg]
+                if arg == 'where':
+                    for key, val in where.items():
+                        parameters[key] = val
+                else:
+                    parameters[arg] = locals()[arg]
         if order_by:
             parameters['orderBy'] = order_by
         if order_by_dir:


### PR DESCRIPTION
the api allows adding a query (where) filters by adding a list of fie…lds and values to filter on, to allow that i've added the where params into the request.

example:
```
user = '<user_name>'
password = '<password>'

base_url = 'https://<mautic_instance_url>'
mautic = MauticBasicAuthClient(base_url=base_url,username=user,password=password)

step = 30

where = {
        'where[0][col]': 'user_id',
        'where[0][expr]': 'in',
        'where[0][val]': '14006831'
}

contacts = Contacts(client=mautic)
contacts_list = contacts.get_list(minimal=True, limit=step,where=where)
```